### PR TITLE
feat: remove setToken action and add API rate limit handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sports-brain-buzz",
-    "version": "9.5.0",
+    "version": "9.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sports-brain-buzz",
-            "version": "9.5.0",
+            "version": "9.6.0",
             "dependencies": {
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sports-brain-buzz",
-    "version": "9.5.0",
+    "version": "9.6.0",
     "private": true,
     "type": "module",
     "description": "A web application for sports enthusiasts using React and TypeScript.",

--- a/src/_application/fetchQuestions.ts
+++ b/src/_application/fetchQuestions.ts
@@ -8,6 +8,9 @@ import { ResponseCode } from '../types/response-code.enum.ts';
 import { QuizStorageService } from './ports.ts';
 import { startTrivia } from './startTrivia.ts';
 
+// Each IP can only access the API once every 5 seconds.
+const API_RATE_LIMIT = 5000;
+
 export const fetchQuestions = async (
     token: string,
     quizStorage: QuizStorageService,
@@ -29,6 +32,9 @@ export const fetchQuestions = async (
             case ResponseCode.NotFound:
                 localStorage.removeItem('sessionToken');
                 await startTrivia({ quizStorage });
+                break;
+            case ResponseCode.RateLimit:
+                await startTrivia({ quizStorage }, API_RATE_LIMIT);
                 break;
             default:
                 throw new Error(`${getApiErrorMessage(responseCode)}`);

--- a/src/_application/fetchToken.ts
+++ b/src/_application/fetchToken.ts
@@ -4,13 +4,12 @@ import { localStorage } from '../_services/store/storageAdapter.ts';
 import { QuizStorageService } from './ports.ts';
 
 export const fetchToken = async (quizStorage: QuizStorageService): Promise<void> => {
-    const { setToken, setFetchTokenError } = quizStorage;
+    const { setFetchTokenError } = quizStorage;
     try {
         const { data } = await quizApiService.fetchToken();
 
         const token = data.token;
         localStorage.setItem('sessionToken', token);
-        setToken();
     } catch (error) {
         setFetchTokenError(`${ERROR_MESSAGE_BASE} Please try again.`);
     }

--- a/src/_application/ports.ts
+++ b/src/_application/ports.ts
@@ -39,7 +39,6 @@ export interface HttpService {
 export interface QuizStorageService {
     state: InitialState;
     startQuiz: () => void;
-    setToken: () => void;
     setFetchTokenError: (message: string) => void;
     setError: (message: string) => void;
     setQuestions: (questionState: QuestionsState[]) => void;

--- a/src/_application/startTrivia.ts
+++ b/src/_application/startTrivia.ts
@@ -1,3 +1,4 @@
+import { delay } from '../_lib/delay.ts';
 import { localStorage } from '../_services/store/storageAdapter.ts';
 import { fetchQuestions } from './fetchQuestions.ts';
 import { fetchToken } from './fetchToken.ts';
@@ -7,11 +8,13 @@ type Dependencies = {
     quizStorage: QuizStorageService;
 };
 
-export const startTrivia = async ({ quizStorage }: Dependencies) => {
+export const startTrivia = async ({ quizStorage }: Dependencies, delayInMs?: number) => {
     const { startQuiz } = quizStorage;
 
     startQuiz();
     const token = localStorage.getItem('sessionToken');
+
+    if (delayInMs) await delay(delayInMs);
 
     if (!token) {
         await fetchToken(quizStorage);

--- a/src/_lib/delay.ts
+++ b/src/_lib/delay.ts
@@ -1,0 +1,7 @@
+export const delay = (delayInMs: number) => {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve(2);
+        }, delayInMs);
+    });
+};

--- a/src/_services/store/quiz-reducer.ts
+++ b/src/_services/store/quiz-reducer.ts
@@ -64,11 +64,6 @@ const setError = (
     error: action.payload,
 });
 
-const setToken = (state: InitialState): InitialState => ({
-    ...state,
-    loading: false,
-});
-
 export const quizReducer = (state: InitialState, action: ActionType): InitialState => {
     switch (action.type) {
         case ActionTypes.START_QUIZ:
@@ -81,8 +76,6 @@ export const quizReducer = (state: InitialState, action: ActionType): InitialSta
             return checkAnswer(state, action);
         case ActionTypes.SET_ERROR:
             return setError(state, action);
-        case ActionTypes.SET_TOKEN:
-            return setToken(state);
         default:
             return state;
     }

--- a/src/_services/store/store-context.ts
+++ b/src/_services/store/store-context.ts
@@ -8,9 +8,6 @@ export const StoreContext = createContext<QuizStorageService>({
     startQuiz(): void {
         throw new Error('Method not implemented.');
     },
-    setToken(): void {
-        throw new Error('Method not implemented.');
-    },
     setFetchTokenError(): void {
         throw new Error('Method not implemented.');
     },

--- a/src/_services/store/store.tsx
+++ b/src/_services/store/store.tsx
@@ -14,7 +14,6 @@ export const Provider: FC<ProviderProps> = ({ children }) => {
     const [state, dispatch] = useReducer(quizReducer, initialState);
 
     const startQuiz = () => dispatch({ type: ActionTypes.START_QUIZ });
-    const setToken = () => dispatch({ type: ActionTypes.SET_TOKEN });
     const setFetchTokenError = (payload: string) =>
         dispatch({
             type: ActionTypes.SET_ERROR,
@@ -41,7 +40,6 @@ export const Provider: FC<ProviderProps> = ({ children }) => {
         () => ({
             state,
             startQuiz,
-            setToken,
             setFetchTokenError,
             setError,
             setQuestions,

--- a/src/_ui/App.tsx
+++ b/src/_ui/App.tsx
@@ -1,4 +1,5 @@
 import React, { lazy, MouseEvent, Suspense, useCallback, useMemo } from 'react';
+
 import { useQuizStorage } from '../_services/store/storageAdapter.ts';
 import { useCheckAnswer } from '../_services/useCheckAnswer.ts';
 import { useNextQuestion } from '../_services/useNextQuestion.ts';

--- a/src/types/action-type.type.ts
+++ b/src/types/action-type.type.ts
@@ -9,5 +9,4 @@ export type ActionType =
           type: typeof ActionTypes.CHECK_ANSWER;
           payload: { answer: string; correctAnswer: string; question: string };
       }
-    | { type: typeof ActionTypes.SET_ERROR; payload: string }
-    | { type: typeof ActionTypes.SET_TOKEN };
+    | { type: typeof ActionTypes.SET_ERROR; payload: string };

--- a/src/types/action-types.enum.ts
+++ b/src/types/action-types.enum.ts
@@ -5,5 +5,4 @@ export const ActionTypes = {
     NEXT_QUESTION: 'NEXT_QUESTION',
     CHECK_ANSWER: 'CHECK_ANSWER',
     SET_ERROR: 'SET_ERROR',
-    SET_TOKEN: 'SET_TOKEN',
 } as const;


### PR DESCRIPTION
This removes the redundant setToken action and its associated methods from various files. Additionally, it introduces a delay function to handle the server-side API rate limit, using the delay in milliseconds parameter.