### PR TITLE
refactor(http): Replace ky with native fetch API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sports-brain-buzz",
-    "version": "15.0.0",
+    "version": "16.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sports-brain-buzz",
-            "version": "15.0.0",
+            "version": "16.0.0",
             "dependencies": {
                 "dompurify": "^3.2.5",
                 "http-errors": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sports-brain-buzz",
-    "version": "15.0.0",
+    "version": "16.0.0",
     "private": true,
     "type": "module",
     "description": "A web application for sports enthusiasts using React and TypeScript.",

--- a/src/_services/http.service.ts
+++ b/src/_services/http.service.ts
@@ -1,39 +1,51 @@
-import ky from 'ky';
-
 import { HttpService } from '../_application/ports.ts';
 
-export const createHttpService = (client: typeof ky): HttpService => ({
+export const httpService: HttpService = {
     async get<T>(url: string): Promise<HttpResponse<T>> {
-        const response = await client.get(url);
-        const data = await response.json<T>();
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+            },
+        });
+        const data = await response.json();
         return { status: response.status, data };
     },
 
     async post<T, U>(url: string, data: U): Promise<HttpResponse<T>> {
-        const response = await client.post(url, { json: data });
-        const responseData = await response.json<T>();
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        const responseData = await response.json();
         return { status: response.status, data: responseData };
     },
 
     async put<T, U>(url: string, data: U): Promise<HttpResponse<T>> {
-        const response = await client.put(url, { json: data });
-        const responseData = await response.json<T>();
+        const response = await fetch(url, {
+            method: 'PUT',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        const responseData = await response.json();
         return { status: response.status, data: responseData };
     },
 
     async delete<T>(url: string): Promise<HttpResponse<T>> {
-        const response = await client.delete(url);
-        const data = await response.json<T>();
+        const response = await fetch(url, {
+            method: 'DELETE',
+            headers: {
+                'Accept': 'application/json',
+            },
+        });
+        const data = await response.json();
         return { status: response.status, data };
     },
-});
-
-// Create the default instance with a common configuration
-const defaultClient = ky.create({
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-// Export the default configured instance
-export const httpService = createHttpService(defaultClient);
+};


### PR DESCRIPTION
## Changes
- Removed `ky` HTTP client dependency
- Implemented HTTP service using native fetch API
- Updated project version to 16.0.0 to reflect breaking changes

## Motivation
This change simplifies our HTTP implementation by utilizing the native fetch API instead of the third-party `ky` library. This reduces our external dependencies and leverages built-in browser capabilities.

## Breaking Changes
- HTTP service implementation now uses native fetch API
- Removed `ky` from dependencies
- Major version bump to 16.0.0 following semver conventions

## Testing
- [ ] Verified all HTTP requests work as expected
- [ ] Confirmed error handling behaves consistently
- [ ] Tested with different response types

## Dependencies
- Removed: `ky@1.8.1`